### PR TITLE
Add a release flow that bumps the version, then publishes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,6 @@ jobs:
           node-version: 'lts/*'
           cache: npm
       - run: npm ci
+      - run: node scripts/check-versions-agree.mjs
       - run: npm run build
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,5 +50,20 @@ jobs:
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
       - name: Authenticate to MCP registry
         run: ./mcp-publisher login github-oidc
+      # Idempotent for the same reason the npm step above is: this job can be
+      # re-run, or dispatched to sync one registry after the other already
+      # succeeded. The registry rejects a repeat version with a 400, which is
+      # "nothing to do" here, not a failure.
       - name: Publish to MCP registry
-        run: ./mcp-publisher publish
+        run: |
+          set +e
+          OUTPUT=$(./mcp-publisher publish 2>&1)
+          STATUS=$?
+          echo "$OUTPUT"
+          if [ $STATUS -ne 0 ]; then
+            if echo "$OUTPUT" | grep -q 'cannot publish duplicate version'; then
+              echo "Already on the MCP registry at this version, skipping"
+              exit 0
+            fi
+            exit $STATUS
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+# Cutting a release is one dispatch of this workflow. It decides the next
+# version, writes it to every file that carries one, tags it, and pushes — the
+# tag is what triggers publish.yml.
+#
+# It exists because the version used to be bumped by hand in three places
+# (package.json, and server.json twice). Miss one and the MCP registry rejects
+# the publish as a duplicate; miss the tag and there is no record of what
+# shipped. Both happened to 0.1.2, which reached npm and the registry with no
+# v0.1.2 tag behind it.
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Which part of the version to increment'
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+      exact:
+        description: 'Exact version to release, e.g. 0.2.0 (overrides the bump choice)'
+        type: string
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: npm
+
+      # Nothing gets a version number until it passes. A tag is hard to retract
+      # once publish.yml has acted on it.
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+      - name: Work out the new version
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+          EXACT: ${{ inputs.exact }}
+        run: |
+          set -euo pipefail
+          if [ -n "$EXACT" ]; then
+            NEW=$(npm version "$EXACT" --no-git-tag-version)
+          else
+            NEW=$(npm version "$BUMP" --no-git-tag-version)
+          fi
+          NEW=${NEW#v}
+          echo "Releasing $NEW"
+          echo "version=$NEW" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse to reuse a published version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if npm view "@stag-build/phonebook@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::$VERSION is already on npm. Pick a higher version."
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "::error::Tag v$VERSION already exists."
+            exit 1
+          fi
+
+      # server.json carries the version twice — once for the server, once for
+      # the npm package it points at. Both have to move together.
+      - name: Sync server.json
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          node -e '
+            const fs = require("fs");
+            const version = process.env.VERSION;
+            const server = JSON.parse(fs.readFileSync("server.json", "utf8"));
+            server.version = version;
+            for (const pkg of server.packages ?? []) pkg.version = version;
+            fs.writeFileSync("server.json", JSON.stringify(server, null, 2) + "\n");
+          '
+          node scripts/check-versions-agree.mjs
+
+      - name: Commit and tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add package.json package-lock.json server.json
+          git commit -m "Release v$VERSION"
+          git tag "v$VERSION"
+          git push origin HEAD:main
+          git push origin "v$VERSION"
+          echo "Tagged v$VERSION — publish.yml takes it from here." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check-versions-agree.mjs
+++ b/scripts/check-versions-agree.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// The version is written in three places: package.json, and server.json twice
+// (once for the server, once for the npm package it points at). They are only
+// meaningful if they agree — a stale server.json publishes fine to npm and is
+// then rejected by the MCP registry as a duplicate, which is how 0.1.2 failed.
+//
+// Run by CI on every push, and by the release workflow after it bumps.
+import { readFileSync } from 'node:fs';
+
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const server = JSON.parse(readFileSync(new URL('../server.json', import.meta.url), 'utf8'));
+
+const found = [
+  ['package.json version', pkg.version],
+  ['server.json version', server.version],
+  ...(server.packages ?? []).map((p, i) => [`server.json packages[${i}].version`, p.version]),
+];
+
+const disagree = found.filter(([, value]) => value !== pkg.version);
+if (disagree.length > 0) {
+  console.error(`Version mismatch. package.json says ${pkg.version}, but:`);
+  for (const [where, value] of disagree) console.error(`  ${where} = ${value}`);
+  console.error('\nRelease with the Release workflow, which writes all three together.');
+  process.exit(1);
+}
+
+console.log(`All ${found.length} version fields agree: ${pkg.version}`);


### PR DESCRIPTION
Fixes the failing publish job in [run 34091575442](https://github.com/stag-build/phonebook/actions/runs/34091575442).

## What broke

```
server returned status 400: invalid version: cannot publish duplicate version
```

`publish.yml` ships whatever `package.json` already says — it has no way to choose a version. So cutting a release meant editing the version by hand in three places and remembering to tag:

| File | Field |
| --- | --- |
| `package.json` | `version` |
| `server.json` | `version` |
| `server.json` | `packages[0].version` |

Both halves went wrong on 0.1.2. It reached npm and the MCP registry with **no `v0.1.2` tag behind it** — the newest tag on the remote is `v0.1.1` — so there is no record of what shipped. And because the job can only re-ship whatever the working tree says, re-running it retries 0.1.2, which the registry refuses.

## Three changes

**`release.yml` — the step that was missing.** One dispatch picks `patch`/`minor`/`major` (or an exact version), runs the tests, writes the new version to all three fields, refuses it if npm or a tag already has that version, then commits and tags. Pushing the tag triggers `publish.yml`, so publishing stays what it always was: ship what is tagged.

**`scripts/check-versions-agree.mjs` — drift can't survive a push.** Fails when the three fields disagree; CI runs it on every push. A stale `server.json` publishes to npm without complaint and is only caught later by the registry, which is exactly the failure above.

**`publish.yml` — the MCP step is now re-runnable.** The npm step beside it already skipped work it had done; the MCP step hard-failed instead. A duplicate-version 400 means the registry is already in the state we want.

## Verification

All four workflow files parse. The drift check was tested against real drift, not just the happy path:

```
$ node scripts/check-versions-agree.mjs
All 3 version fields agree: 0.1.2

$ # with server.json packages[0].version set back to 0.1.1
$ node scripts/check-versions-agree.mjs
Version mismatch. package.json says 0.1.2, but:
  server.json packages[0].version = 0.1.1
exit=1
```

The bump-and-sync was dry-run locally and touches exactly `package.json`, `package-lock.json` and `server.json`.

## After merging

The release flow can cut the next version. Worth deciding deliberately rather than defaulting to `patch`: if #1 merges first, the manifest schema changes in it — `tags` removed, `previewName` semantics changed — are breaking for anything reading a bundle, which at `0.x` argues for `minor` (0.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)