### PR TITLE
Report what each component is missing, not just what its previews got wrong

### DIFF
--- a/src/mcp/gaps-report.test.ts
+++ b/src/mcp/gaps-report.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeGaps } from './server.js';
+import type { CoverageReport, ScannedComponent } from '../scan/types.js';
+
+function component(
+  name: string,
+  gaps: { rule: string; severity: 'warning' | 'info' }[],
+): ScannedComponent {
+  return {
+    name,
+    file: `Sources/${name}.swift`,
+    line: 1,
+    previews: [],
+    gaps: gaps.map((g) => ({ ...g, message: `${name} message`, suggestion: `${name} suggestion` })),
+  };
+}
+
+function report(components: ScannedComponent[]): CoverageReport {
+  return {
+    platform: 'ios',
+    components,
+    orphanPreviews: [],
+    extraLocales: [],
+    stats: {
+      components: components.length,
+      withPreview: 0,
+      withDarkPreview: 0,
+      totalPreviews: 0,
+      hintCount: 0,
+      gapCount: components.reduce((sum, c) => sum + (c.gaps ?? []).length, 0),
+      componentsWithGaps: components.length,
+      selfPreviewed: 0,
+    },
+  };
+}
+
+describe('summarizeGaps', () => {
+  it('says so plainly when nothing is missing', () => {
+    expect(summarizeGaps(report([]))).toBe('Missing previews (0)');
+  });
+
+  it('groups every gap under its component', () => {
+    const text = summarizeGaps(
+      report([
+        component('StatusRow', [
+          { rule: 'no-preview', severity: 'warning' },
+          { rule: 'state-bool', severity: 'warning' },
+        ]),
+      ]),
+    );
+
+    expect(text).toContain('Sources/StatusRow.swift:1 StatusRow (2 missing)');
+    expect(text).toContain('  [no-preview]');
+    expect(text).toContain('  [state-bool]');
+    expect(text).toContain('Missing previews (2 across 1 component)');
+  });
+
+  it('puts the components missing the most first', () => {
+    const text = summarizeGaps(
+      report([
+        component('Thin', [{ rule: 'no-preview', severity: 'warning' }]),
+        component('Rich', [
+          { rule: 'no-preview', severity: 'warning' },
+          { rule: 'state-bool', severity: 'warning' },
+          { rule: 'state-enum', severity: 'warning' },
+        ]),
+      ]),
+    );
+
+    expect(text.indexOf('Rich')).toBeLessThan(text.indexOf('Thin'));
+  });
+
+  it('caps components, not lines, so a capped report still shows whole components', () => {
+    const many = Array.from({ length: 75 }, (_, i) =>
+      component(`View${String(i).padStart(2, '0')}`, [
+        { rule: 'no-preview', severity: 'warning' },
+        { rule: 'state-bool', severity: 'warning' },
+      ]),
+    );
+    const text = summarizeGaps(report(many));
+
+    expect(text).toContain('... and 15 more components (see JSON)');
+    // Every component that is shown carries both of its gaps.
+    const headers = text.split('\n').filter((l) => l.includes(' (2 missing)'));
+    expect(headers).toHaveLength(60);
+    expect(text).toContain('Missing previews (150 across 75 components)');
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -40,6 +40,10 @@ function summarizeCoverage(report: CoverageReport): string {
     `With preview: ${stats.withPreview}`,
     `Without preview: ${withoutPreview}`,
     `With dark preview: ${stats.withDarkPreview}`,
+    `Components with missing previews: ${stats.componentsWithGaps}`,
+    report.extraLocales.length > 0
+      ? `Localizations beyond the development language: ${report.extraLocales.join(', ')}`
+      : 'Localizations beyond the development language: none',
     orphanCount > 0
       ? `Orphan previews (could not be matched to a component in the same file): ${orphanCount}`
       : `Orphan previews (unmatched to a component): ${orphanCount}`,
@@ -47,6 +51,50 @@ function summarizeCoverage(report: CoverageReport): string {
 }
 
 const HINT_LIST_CAP = 40;
+const GAP_LIST_CAP = 60;
+
+/**
+ * What each component is missing, which is the half `summarizeHints` cannot
+ * see: a hint needs a preview to exist before it can say anything about it.
+ *
+ * This is a to-do list for the agent reading it, ordered so the components with
+ * nothing at all come first. It reports; it never edits.
+ */
+function summarizeGaps(report: CoverageReport): string {
+  const entries = report.components.flatMap((c) =>
+    (c.gaps ?? []).map((gap) => ({ component: c, gap })),
+  );
+
+  if (entries.length === 0) {
+    return 'Missing previews (0)';
+  }
+
+  const severityRank = (rule: string, severity: string) =>
+    rule === 'no-preview' ? 0 : severity === 'warning' ? 1 : 2;
+  entries.sort(
+    (a, b) =>
+      severityRank(a.gap.rule, a.gap.severity) - severityRank(b.gap.rule, b.gap.severity) ||
+      a.component.file.localeCompare(b.component.file) ||
+      a.component.line - b.component.line,
+  );
+
+  const shown = entries.slice(0, GAP_LIST_CAP);
+  const lines = shown.map(
+    (e) =>
+      `${e.component.file}:${e.component.line} ${e.component.name} [${e.gap.rule}] ${e.gap.message} -> ${e.gap.suggestion}`,
+  );
+  const remaining = entries.length - shown.length;
+  if (remaining > 0) {
+    lines.push(`... and ${remaining} more (see JSON)`);
+  }
+
+  return [
+    `Missing previews (${entries.length})`,
+    ...lines,
+    '',
+    'Read each component before writing previews: the states above are inferred from its parameters, and only its source says which of them are worth a preview. Call get_preview_guidance for the naming convention and a template.',
+  ].join('\n');
+}
 
 function summarizeHints(report: CoverageReport): string {
   const allPreviews = [
@@ -145,7 +193,7 @@ export async function runMcpServer(): Promise<void> {
     'analyze_coverage',
     {
       description:
-        'Scan the codebase for UI components and the previews that cover them: which have previews, which states/themes are missing. Read-only.',
+        'Scan the codebase for UI components and the previews that cover them, and report what each component is missing: states implied by its parameters, dark theme, large text, and localization when the project ships one. Read-only — it reports the gaps, it does not write previews.',
       inputSchema: {
         dir: z.string().default('.').describe('Project directory containing phonebook.config.json'),
       },
@@ -179,8 +227,9 @@ export async function runMcpServer(): Promise<void> {
       }
 
       const summary = summarizeCoverage(report);
+      const gaps = summarizeGaps(report);
       const hints = summarizeHints(report);
-      return textResult(`${summary}\n\n${hints}\n\n${JSON.stringify(report, null, 2)}`);
+      return textResult(`${summary}\n\n${gaps}\n\n${hints}\n\n${JSON.stringify(report, null, 2)}`);
     },
   );
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -31,7 +31,7 @@ function textResult(text: string) {
   return { content: [{ type: 'text' as const, text }] };
 }
 
-function summarizeCoverage(report: CoverageReport): string {
+export function summarizeCoverage(report: CoverageReport): string {
   const { stats } = report;
   const withoutPreview = stats.components - stats.withPreview;
   const orphanCount = report.orphanPreviews.length;
@@ -51,52 +51,62 @@ function summarizeCoverage(report: CoverageReport): string {
 }
 
 const HINT_LIST_CAP = 40;
-const GAP_LIST_CAP = 60;
+const GAP_COMPONENT_CAP = 60;
 
 /**
  * What each component is missing, which is the half `summarizeHints` cannot
  * see: a hint needs a preview to exist before it can say anything about it.
  *
- * This is a to-do list for the agent reading it, ordered so the components with
- * nothing at all come first. It reports; it never edits.
+ * Grouped by component rather than listed flat. A flat list sorted by severity
+ * put every "has no preview" first, and on a repository with a hundred of them
+ * the cap fell before a single state gap was reached — the specific, useful
+ * half of the report never reached the reader. Components carrying the most
+ * missing states come first for the same reason.
+ *
+ * It reports; it never edits.
  */
-function summarizeGaps(report: CoverageReport): string {
-  const entries = report.components.flatMap((c) =>
-    (c.gaps ?? []).map((gap) => ({ component: c, gap })),
-  );
+export function summarizeGaps(report: CoverageReport): string {
+  const withGaps = report.components.filter((c) => (c.gaps ?? []).length > 0);
+  const total = withGaps.reduce((sum, c) => sum + (c.gaps ?? []).length, 0);
 
-  if (entries.length === 0) {
+  if (total === 0) {
     return 'Missing previews (0)';
   }
 
-  const severityRank = (rule: string, severity: string) =>
-    rule === 'no-preview' ? 0 : severity === 'warning' ? 1 : 2;
-  entries.sort(
+  const warnings = (component: (typeof withGaps)[number]) =>
+    (component.gaps ?? []).filter((g) => g.severity === 'warning').length;
+
+  const ordered = [...withGaps].sort(
     (a, b) =>
-      severityRank(a.gap.rule, a.gap.severity) - severityRank(b.gap.rule, b.gap.severity) ||
-      a.component.file.localeCompare(b.component.file) ||
-      a.component.line - b.component.line,
+      warnings(b) - warnings(a) ||
+      (b.gaps ?? []).length - (a.gaps ?? []).length ||
+      a.file.localeCompare(b.file) ||
+      a.line - b.line,
   );
 
-  const shown = entries.slice(0, GAP_LIST_CAP);
-  const lines = shown.map(
-    (e) =>
-      `${e.component.file}:${e.component.line} ${e.component.name} [${e.gap.rule}] ${e.gap.message} -> ${e.gap.suggestion}`,
-  );
-  const remaining = entries.length - shown.length;
+  const shown = ordered.slice(0, GAP_COMPONENT_CAP);
+  const blocks = shown.map((component) => {
+    const gaps = component.gaps ?? [];
+    const header = `${component.file}:${component.line} ${component.name} (${gaps.length} missing)`;
+    const lines = gaps.map((g) => `  [${g.rule}] ${g.message} -> ${g.suggestion}`);
+    return [header, ...lines].join('\n');
+  });
+
+  const remaining = ordered.length - shown.length;
   if (remaining > 0) {
-    lines.push(`... and ${remaining} more (see JSON)`);
+    blocks.push(`... and ${remaining} more component${remaining === 1 ? '' : 's'} (see JSON)`);
   }
 
   return [
-    `Missing previews (${entries.length})`,
-    ...lines,
+    `Missing previews (${total} across ${withGaps.length} component${withGaps.length === 1 ? '' : 's'})`,
+    '',
+    ...blocks,
     '',
     'Read each component before writing previews: the states above are inferred from its parameters, and only its source says which of them are worth a preview. Call get_preview_guidance for the naming convention and a template.',
   ].join('\n');
 }
 
-function summarizeHints(report: CoverageReport): string {
+export function summarizeHints(report: CoverageReport): string {
   const allPreviews = [
     ...report.components.flatMap((c) => c.previews),
     ...report.orphanPreviews,

--- a/src/scan/android.ts
+++ b/src/scan/android.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import type { CoverageReport, ScannedComponent, ScannedPreview } from './types.js';
 import { previewHints } from './hints.js';
+import { componentGaps, type ComponentProperty, type PropertyKind } from './gaps.js';
 
 /**
  * Regex-based heuristic scanner for Jetpack Compose `@Composable` / `@Preview`
@@ -11,6 +12,8 @@ import { previewHints } from './hints.js';
 export async function scanAndroid(projectDir: string, modules: string[]): Promise<CoverageReport> {
   const components: ScannedComponent[] = [];
   const orphanPreviews: ScannedPreview[] = [];
+  const extraLocales = await detectLocales(projectDir, modules);
+  const enumTypes = new Set<string>();
 
   for (const module of modules) {
     const moduleDir = join(projectDir, ...module.split(':').filter(Boolean));
@@ -20,6 +23,8 @@ export async function scanAndroid(projectDir: string, modules: string[]): Promis
     for (const file of files) {
       const relFile = relative(projectDir, file);
       const content = await readFile(file, 'utf8');
+      for (const enumName of findEnums(content)) enumTypes.add(enumName);
+
       const { fileComponents, filePreviews } = scanKotlinFile(content, relFile);
 
       for (const comp of fileComponents) components.push(comp);
@@ -31,10 +36,25 @@ export async function scanAndroid(projectDir: string, modules: string[]): Promis
   components.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
   orphanPreviews.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
 
+  for (const component of components) {
+    const gaps = componentGaps({
+      platform: 'android',
+      component: component.name,
+      properties: component.properties ?? [],
+      previewNames: component.previews.map((p) => p.displayName ?? p.name),
+      hasDarkPreview: component.previews.some((p) => p.dark),
+      previewText: component.previews.map((p) => p.annotationText ?? '').join('\n'),
+      extraLocales,
+      enumTypes: [...enumTypes],
+    });
+    if (gaps.length > 0) component.gaps = gaps;
+  }
+
   return {
     platform: 'android',
     components,
     orphanPreviews,
+    extraLocales,
     stats: computeStats(components, orphanPreviews),
   };
 }
@@ -102,11 +122,13 @@ function scanKotlinFile(
         },
       });
     } else {
+      const properties = findParameters(content, fn.funIndex);
       fileComponents.push({
         name: fn.name,
         file: relFile,
         line: fn.line,
         previews: [],
+        ...(properties.length > 0 ? { properties } : {}),
       });
     }
   }
@@ -120,11 +142,13 @@ function scanKotlinFile(
     if (wrapperTarget) {
       filePreviews.push(preview);
     } else {
+      const properties = findParameters(content, fn.funIndex);
       fileComponents.push({
         name: fn.name,
         file: relFile,
         line: fn.line,
         previews: [preview],
+        ...(properties.length > 0 ? { properties } : {}),
       });
     }
   }
@@ -148,6 +172,112 @@ function bestPrefixMatch(name: string, components: ScannedComponent[]): ScannedC
  * the block of annotations (e.g. `@Composable`, `@Preview(...)`) found within
  * roughly 5 lines above the `fun` keyword.
  */
+/**
+ * Parameters of the composable whose `fun` keyword starts at `funIndex`.
+ *
+ * A composable's parameters are its states: a `Boolean` has two values, a
+ * nullable can be absent, a `List` can be empty. `Modifier` is excluded because
+ * it configures placement rather than describing a state.
+ */
+function findParameters(content: string, funIndex: number): ComponentProperty[] {
+  const open = content.indexOf('(', funIndex);
+  if (open === -1) return [];
+  let depth = 0;
+  let close = -1;
+  const cap = Math.min(content.length, open + 4000);
+  for (let i = open; i < cap; i++) {
+    if (content[i] === '(') depth++;
+    else if (content[i] === ')') {
+      depth--;
+      if (depth === 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close === -1) return [];
+
+  const properties: ComponentProperty[] = [];
+  for (const raw of splitTopLevel(content.slice(open + 1, close))) {
+    const match = raw.match(/^\s*(?:@\w+(?:\([^)]*\))?\s+)*(\w+)\s*:\s*([^=]+)/);
+    if (!match) continue;
+    const name = match[1];
+    const type = match[2].trim();
+    if (type.startsWith('Modifier')) continue;
+    properties.push({ name, type, kind: classifyKotlinType(type) });
+  }
+  return properties;
+}
+
+/** Enum type names declared in this file. */
+function findEnums(content: string): string[] {
+  const results: string[] = [];
+  const regex = /\benum\s+class\s+([A-Z]\w*)/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(content)) !== null) results.push(match[1]);
+  return results;
+}
+
+/** Splits a parameter list on commas that are not inside brackets. */
+function splitTopLevel(text: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const char of text) {
+    if (char === '<' || char === '(' || char === '[') depth++;
+    else if (char === '>' || char === ')' || char === ']') depth--;
+    if (char === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) parts.push(current);
+  return parts;
+}
+
+/** Types whose values are a spectrum rather than a set of states worth previewing. */
+const SCALAR_TYPES = new Set([
+  'String', 'Int', 'Long', 'Float', 'Double', 'Char', 'Dp', 'TextUnit', 'Color',
+  'Any', 'Unit',
+]);
+
+function classifyKotlinType(type: string): PropertyKind {
+  const bare = type.replace(/\s+/g, '');
+  if (bare.endsWith('?')) return 'optional';
+  if (/^(List|Set|Array|Collection|Iterable|Map)</.test(bare)) return 'collection';
+  if (bare === 'Boolean') return 'bool';
+  if (bare.includes('->')) return 'other';
+  if (SCALAR_TYPES.has(bare)) return 'other';
+  if (/^[A-Z]\w*$/.test(bare)) return 'enum-like';
+  return 'other';
+}
+
+/**
+ * Locales the project ships, from `res/values-<code>` resource directories.
+ * The unqualified `values` directory is the default language, not a locale.
+ */
+async function detectLocales(projectDir: string, modules: string[]): Promise<string[]> {
+  const found = new Set<string>();
+  for (const module of modules) {
+    const moduleDir = join(projectDir, ...module.split(':').filter(Boolean));
+    const resDir = join(moduleDir, 'src', 'main', 'res');
+    let entries;
+    try {
+      entries = await readdir(resDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const match = entry.name.match(/^values-([a-z]{2}(?:-r[A-Z]{2})?)$/);
+      if (match) found.add(match[1].replace('-r', '-'));
+    }
+  }
+  return [...found].sort();
+}
+
 function findAnnotatedFunctions(content: string): RawFunction[] {
   const results: RawFunction[] = [];
   const funRegex = /\bfun\s+([A-Z]\w*)\s*\(/g;
@@ -218,6 +348,10 @@ function computeStats(components: ScannedComponent[], orphanPreviews: ScannedPre
     components.reduce((sum, c) => sum + c.previews.length, 0) + orphanPreviews.length;
   const allPreviews = [...components.flatMap((c) => c.previews), ...orphanPreviews];
   const hintCount = allPreviews.reduce((sum, p) => sum + (p.hints?.length ?? 0), 0);
+  const gapCount = components.reduce((sum, c) => sum + (c.gaps?.length ?? 0), 0);
+  const componentsWithGaps = components.filter((c) =>
+    (c.gaps ?? []).some((g) => g.severity === 'warning'),
+  ).length;
   const selfPreviewed = components.filter((c) =>
     c.previews.some((p) => p.name === c.name && p.line === c.line),
   ).length;
@@ -227,6 +361,8 @@ function computeStats(components: ScannedComponent[], orphanPreviews: ScannedPre
     withDarkPreview,
     totalPreviews,
     hintCount,
+    gapCount,
+    componentsWithGaps,
     selfPreviewed,
   };
 }

--- a/src/scan/gaps.scan.test.ts
+++ b/src/scan/gaps.scan.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { scanIos } from './ios.js';
+import { scanAndroid } from './android.js';
+
+describe('scanIos gap detection', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), 'phonebook-gaps-ios-'));
+    const srcDir = join(projectDir, 'Sources');
+    await mkdir(srcDir, { recursive: true });
+
+    await writeFile(
+      join(srcDir, 'StatusRow.swift'),
+      `import SwiftUI
+
+enum LoadingState { case idle, loading }
+
+class RouterPath {}
+
+struct StatusRow: View {
+  let isFocused: Bool
+  var replies: [Status]
+  var author: Account?
+  var state: LoadingState
+  var router: RouterPath
+  private let title: String
+  @Binding var draft: String
+
+  var body: some View {
+    Text(title)
+  }
+
+  var accessibilityLabel: String {
+    title
+  }
+}
+
+#Preview("StatusRow/Default") {
+  StatusRow(isFocused: false, replies: [reply], author: .sample, state: .idle, draft: .constant(""))
+}
+`,
+    );
+
+    await writeFile(
+      join(srcDir, 'CoveredRow.swift'),
+      `import SwiftUI
+
+struct CoveredRow: View {
+  var replies: [Status]
+  var author: Account?
+
+  var body: some View { Text("hi") }
+}
+
+#Preview("CoveredRow/Empty") {
+  CoveredRow(replies: [], author: nil)
+}
+`,
+    );
+
+    await writeFile(
+      join(srcDir, 'QuietBadge.swift'),
+      `import SwiftUI
+
+struct QuietBadge: View {
+  var body: some View { Text("hi") }
+}
+`,
+    );
+
+    // A localized project: two .lproj directories beyond Base.
+    for (const locale of ['Base', 'de', 'he']) {
+      await mkdir(join(projectDir, 'Resources', `${locale}.lproj`), { recursive: true });
+    }
+  });
+
+  afterAll(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+  });
+
+  it('reads stored properties and skips body and computed properties', async () => {
+    const report = await scanIos(projectDir);
+    const row = report.components.find((c) => c.name === 'StatusRow');
+    const names = (row?.properties ?? []).map((p) => p.name);
+
+    expect(names).toContain('isFocused');
+    expect(names).toContain('replies');
+    expect(names).toContain('author');
+    expect(names).toContain('draft');
+    expect(names).not.toContain('body');
+    expect(names).not.toContain('accessibilityLabel');
+  });
+
+  it('classifies each property by the states it implies', async () => {
+    const report = await scanIos(projectDir);
+    const row = report.components.find((c) => c.name === 'StatusRow');
+    const kind = (name: string) => row?.properties?.find((p) => p.name === name)?.kind;
+
+    expect(kind('isFocused')).toBe('bool');
+    expect(kind('replies')).toBe('collection');
+    expect(kind('author')).toBe('optional');
+    expect(kind('state')).toBe('enum-like');
+    expect(kind('title')).toBe('other');
+  });
+
+  it('reports the states one preview leaves uncovered', async () => {
+    const report = await scanIos(projectDir);
+    const row = report.components.find((c) => c.name === 'StatusRow');
+    const rules = (row?.gaps ?? []).map((g) => g.rule);
+
+    expect(rules).toContain('state-bool');
+    expect(rules).toContain('state-collection');
+    expect(rules).toContain('state-optional');
+    expect(rules).toContain('theme-dark');
+    expect(rules).not.toContain('no-preview');
+  });
+
+  it('takes a preview that passes the property itself as covering that state', async () => {
+    const report = await scanIos(projectDir);
+    const covered = report.components.find((c) => c.name === 'CoveredRow');
+    const rules = (covered?.gaps ?? []).map((g) => g.rule);
+
+    expect(rules).not.toContain('state-optional');
+    expect(rules).not.toContain('state-collection');
+  });
+
+  it('asks for enum cases only for a type the project declares as an enum', async () => {
+    const report = await scanIos(projectDir);
+    const row = report.components.find((c) => c.name === 'StatusRow');
+    const enumGaps = (row?.gaps ?? []).filter((g) => g.rule === 'state-enum');
+
+    expect(enumGaps).toHaveLength(1);
+    expect(enumGaps[0].message).toContain('LoadingState');
+    expect(enumGaps.some((g) => g.message.includes('RouterPath'))).toBe(false);
+  });
+
+  it('leaves the development language out of the project locales', async () => {
+    const withProject = await mkdtemp(join(tmpdir(), 'phonebook-gaps-devregion-'));
+    await mkdir(join(withProject, 'App.xcodeproj'), { recursive: true });
+    await writeFile(
+      join(withProject, 'App.xcodeproj', 'project.pbxproj'),
+      'developmentRegion = en;\n',
+    );
+    for (const locale of ['en', 'de']) {
+      await mkdir(join(withProject, `${locale}.lproj`), { recursive: true });
+    }
+
+    const report = await scanIos(withProject);
+    expect(report.extraLocales).toEqual(['de']);
+    await rm(withProject, { recursive: true, force: true });
+  });
+
+  it('reports a component with no preview at all', async () => {
+    const report = await scanIos(projectDir);
+    const badge = report.components.find((c) => c.name === 'QuietBadge');
+    expect((badge?.gaps ?? []).map((g) => g.rule)).toContain('no-preview');
+  });
+
+  it('finds the project locales and excludes Base', async () => {
+    const report = await scanIos(projectDir);
+    expect(report.extraLocales).toEqual(['de', 'he']);
+    const row = report.components.find((c) => c.name === 'StatusRow');
+    expect((row?.gaps ?? []).map((g) => g.rule)).toContain('localization');
+  });
+
+  it('counts components carrying a warning-level gap', async () => {
+    const report = await scanIos(projectDir);
+    expect(report.stats.componentsWithGaps).toBe(3);
+    expect(report.stats.gapCount).toBeGreaterThan(0);
+  });
+});
+
+describe('scanAndroid gap detection', () => {
+  let projectDir: string;
+
+  beforeAll(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), 'phonebook-gaps-android-'));
+    const srcDir = join(projectDir, 'app', 'src', 'main', 'java', 'dev', 'stag');
+    await mkdir(srcDir, { recursive: true });
+    await mkdir(join(projectDir, 'app', 'src', 'main', 'res', 'values-de'), { recursive: true });
+    await mkdir(join(projectDir, 'app', 'src', 'main', 'res', 'values'), { recursive: true });
+
+    await writeFile(
+      join(srcDir, 'PrimaryButton.kt'),
+      `package dev.stag
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun PrimaryButton(
+    text: String,
+    enabled: Boolean,
+    items: List<String>,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Text(text)
+}
+
+@Preview(name = "PrimaryButton/Enabled")
+@Composable
+private fun PrimaryButtonPreview() {
+    PrimaryButton(text = "Continue", enabled = true, items = emptyList(), onClick = {})
+}
+`,
+    );
+  });
+
+  afterAll(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+  });
+
+  it('reads composable parameters and skips Modifier', async () => {
+    const report = await scanAndroid(projectDir, [':app']);
+    const button = report.components.find((c) => c.name === 'PrimaryButton');
+    const names = (button?.properties ?? []).map((p) => p.name);
+
+    expect(names).toContain('text');
+    expect(names).toContain('enabled');
+    expect(names).toContain('items');
+    expect(names).not.toContain('modifier');
+  });
+
+  it('classifies Kotlin types and reports the uncovered states', async () => {
+    const report = await scanAndroid(projectDir, [':app']);
+    const button = report.components.find((c) => c.name === 'PrimaryButton');
+    const kind = (name: string) => button?.properties?.find((p) => p.name === name)?.kind;
+
+    expect(kind('enabled')).toBe('bool');
+    expect(kind('items')).toBe('collection');
+    expect(kind('onClick')).toBe('other');
+
+    const rules = (button?.gaps ?? []).map((g) => g.rule);
+    expect(rules).toContain('state-bool');
+    expect(rules).toContain('state-collection');
+  });
+
+  it('finds locales from resource directories and suggests Android syntax', async () => {
+    const report = await scanAndroid(projectDir, [':app']);
+    expect(report.extraLocales).toEqual(['de']);
+
+    const button = report.components.find((c) => c.name === 'PrimaryButton');
+    const dark = (button?.gaps ?? []).find((g) => g.rule === 'theme-dark');
+    expect(dark?.suggestion).toContain('UI_MODE_NIGHT_YES');
+  });
+});

--- a/src/scan/gaps.test.ts
+++ b/src/scan/gaps.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { componentGaps, type CoverageGapInput } from './gaps.js';
+
+function input(overrides: Partial<CoverageGapInput> = {}): CoverageGapInput {
+  return {
+    platform: 'ios',
+    component: 'StatusRow',
+    properties: [],
+    previewNames: ['StatusRow/Default'],
+    hasDarkPreview: true,
+    previewText: '#Preview("StatusRow/Default") { .preferredColorScheme(.dark) }',
+    extraLocales: [],
+    ...overrides,
+  };
+}
+
+const rules = (gaps: { rule: string }[]) => gaps.map((g) => g.rule);
+
+describe('componentGaps', () => {
+  it('reports a component that has no preview at all', () => {
+    const gaps = componentGaps(input({ previewNames: [], previewText: '', hasDarkPreview: false }));
+    expect(rules(gaps)).toContain('no-preview');
+    expect(gaps.find((g) => g.rule === 'no-preview')?.severity).toBe('warning');
+  });
+
+  it('asks for both values of a Bool when only one preview exists', () => {
+    const gaps = componentGaps(
+      input({ properties: [{ name: 'isFocused', type: 'Bool', kind: 'bool' }] }),
+    );
+    const gap = gaps.find((g) => g.rule === 'state-bool');
+    expect(gap).toBeDefined();
+    expect(gap?.message).toContain('isFocused');
+  });
+
+  it('accepts a Bool once two previews cover it', () => {
+    const gaps = componentGaps(
+      input({
+        properties: [{ name: 'isFocused', type: 'Bool', kind: 'bool' }],
+        previewNames: ['StatusRow/Focused', 'StatusRow/Unfocused'],
+      }),
+    );
+    expect(rules(gaps)).not.toContain('state-bool');
+  });
+
+  it('asks for the absent case of an Optional, and takes an Empty preview as covering it', () => {
+    const properties = [{ name: 'author', type: 'Account?', kind: 'optional' as const }];
+    expect(rules(componentGaps(input({ properties })))).toContain('state-optional');
+
+    const covered = componentGaps(
+      input({ properties, previewNames: ['StatusRow/Default', 'StatusRow/Empty'] }),
+    );
+    expect(rules(covered)).not.toContain('state-optional');
+  });
+
+  it('asks for the empty case of a collection', () => {
+    const gaps = componentGaps(
+      input({ properties: [{ name: 'replies', type: '[Status]', kind: 'collection' }] }),
+    );
+    expect(rules(gaps)).toContain('state-collection');
+  });
+
+  it('asks for a preview per case only when the type really is an enum', () => {
+    const properties = [{ name: 'state', type: 'LoadingState', kind: 'enum-like' as const }];
+
+    const declared = componentGaps(input({ properties, enumTypes: ['LoadingState'] }));
+    const gap = declared.find((g) => g.rule === 'state-enum');
+    expect(gap?.severity).toBe('warning');
+    expect(gap?.suggestion).toContain('LoadingState');
+
+    // A class or struct of the same shape has no finite set of cases to cover.
+    expect(rules(componentGaps(input({ properties, enumTypes: ['SomethingElse'] })))).not.toContain(
+      'state-enum',
+    );
+    expect(rules(componentGaps(input({ properties })))).not.toContain('state-enum');
+  });
+
+  it('reports a missing dark preview only when some preview exists', () => {
+    expect(rules(componentGaps(input({ hasDarkPreview: false })))).toContain('theme-dark');
+    expect(
+      rules(componentGaps(input({ previewNames: [], previewText: '', hasDarkPreview: false }))),
+    ).not.toContain('theme-dark');
+  });
+
+  it('reports missing large-text coverage and stops once a preview declares it', () => {
+    expect(rules(componentGaps(input()))).toContain('dynamic-type');
+    const covered = componentGaps(
+      input({ previewText: '#Preview { StatusRow().dynamicTypeSize(.accessibility3) }' }),
+    );
+    expect(rules(covered)).not.toContain('dynamic-type');
+  });
+
+  it('stays silent about localization on an unlocalized project', () => {
+    expect(rules(componentGaps(input({ extraLocales: [] })))).not.toContain('localization');
+  });
+
+  it('names the locales the project actually ships', () => {
+    const gap = componentGaps(input({ extraLocales: ['de', 'fr', 'he'] })).find(
+      (g) => g.rule === 'localization',
+    );
+    expect(gap?.message).toContain('de');
+    expect(gap?.suggestion).toContain('de');
+  });
+
+  it('gives the platform its own suggestion syntax', () => {
+    const ios = componentGaps(input({ hasDarkPreview: false }));
+    const android = componentGaps(input({ platform: 'android', hasDarkPreview: false }));
+    expect(ios.find((g) => g.rule === 'theme-dark')?.suggestion).toContain('preferredColorScheme');
+    expect(android.find((g) => g.rule === 'theme-dark')?.suggestion).toContain('UI_MODE_NIGHT_YES');
+  });
+});

--- a/src/scan/gaps.ts
+++ b/src/scan/gaps.ts
@@ -1,0 +1,196 @@
+/**
+ * Coverage gaps: what a component is *missing*, as opposed to what an existing
+ * preview got wrong.
+ *
+ * `hints.ts` answers "this preview's name promises something its annotation
+ * doesn't declare". That only ever fires on a preview that already exists, so a
+ * component with no previews at all — or one preview standing in for four
+ * states — produces no hints and reads as fine.
+ *
+ * This module answers the other half: given what a component actually is (its
+ * stored properties or parameters) and what the project supports (its locales),
+ * which previews *should* exist and don't. The output is guidance for an agent
+ * to act on, not a verdict — Phonebook renders previews, it never writes them,
+ * and whether a state is worth covering is a judgment the agent makes with the
+ * component's source in front of it.
+ */
+
+export type PropertyKind = 'bool' | 'optional' | 'collection' | 'enum-like' | 'other';
+
+export interface ComponentProperty {
+  name: string;
+  /** Type as written in source, e.g. "Bool", "[Status]", "Status?". */
+  type: string;
+  kind: PropertyKind;
+}
+
+export interface CoverageGap {
+  rule: string;
+  severity: 'warning' | 'info';
+  message: string;
+  suggestion: string;
+}
+
+export interface CoverageGapInput {
+  platform: 'android' | 'ios';
+  component: string;
+  properties: ComponentProperty[];
+  /** Display names of the previews already covering this component. */
+  previewNames: string[];
+  /** True when at least one existing preview declares a dark configuration. */
+  hasDarkPreview: boolean;
+  /** Raw text of every existing preview for this component, for "already declares it" checks. */
+  previewText: string;
+  /** Locales the project ships, beyond its development language. Empty when unlocalized. */
+  extraLocales: string[];
+  /** Enum types declared anywhere in the project. A property of one of these
+   * has a known, finite set of states; a property of any other named type is
+   * left alone rather than guessed at. */
+  enumTypes?: string[];
+}
+
+/** A state name the previews already mention, however it is spelled. */
+function covers(input: CoverageGapInput, ...words: string[]): boolean {
+  const haystack = [...input.previewNames, input.previewText].join(' ').toLowerCase();
+  return words.some((w) => haystack.includes(w.toLowerCase()));
+}
+
+/**
+ * True when some preview passes *this* property in its absent or empty form.
+ *
+ * Checked against the property by name rather than by looking for "nil"
+ * anywhere: a preview that passes `author: nil` covers the absent author, and
+ * says nothing about an empty `replies` in the same call.
+ */
+function coversPropertyAs(input: CoverageGapInput, property: string, forms: RegExp): boolean {
+  const pattern = new RegExp(`\\b${property}\\s*[:=]\\s*(?:${forms.source})`, 'i');
+  return pattern.test(input.previewText);
+}
+
+const ABSENT_FORMS = /nil|null|\.none|None/;
+const EMPTY_FORMS = /\[\s*\]|emptyList\(\)|emptySet\(\)|\.init\(\)|listOf\(\)|setOf\(\)/;
+
+function stateCount(input: CoverageGapInput): number {
+  // A component with one preview has one state covered no matter what that
+  // preview is called; "Default" is not two states.
+  return new Set(input.previewNames.map((n) => n.toLowerCase())).size;
+}
+
+const IOS_ENV = {
+  dark: '.preferredColorScheme(.dark)',
+  dynamicType: '.dynamicTypeSize(.accessibility3)',
+  locale: (code: string) => `.environment(\\.locale, .init(identifier: "${code}"))`,
+};
+
+const ANDROID_ENV = {
+  dark: '@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)',
+  dynamicType: '@Preview(fontScale = 1.5f)',
+  locale: (code: string) => `@Preview(locale = "${code}")`,
+};
+
+export function componentGaps(input: CoverageGapInput): CoverageGap[] {
+  const gaps: CoverageGap[] = [];
+  const env = input.platform === 'ios' ? IOS_ENV : ANDROID_ENV;
+  const previewCount = input.previewNames.length;
+
+  if (previewCount === 0) {
+    gaps.push({
+      rule: 'no-preview',
+      severity: 'warning',
+      message: `"${input.component}" has no preview, so it never reaches the gallery.`,
+      suggestion: 'add one preview per meaningful state; call get_preview_guidance for the template',
+    });
+  }
+
+  for (const prop of input.properties) {
+    if (prop.kind === 'bool') {
+      const both = stateCount(input) >= 2;
+      if (!both) {
+        gaps.push({
+          rule: 'state-bool',
+          severity: 'warning',
+          message: `"${input.component}" takes ${prop.name}: ${prop.type}, which has two states, but ${previewCount === 0 ? 'no preview covers either' : 'only one preview exists'}.`,
+          suggestion: `one preview per value of ${prop.name}, named "${input.component}/<State>"`,
+        });
+      }
+      continue;
+    }
+
+    if (prop.kind === 'optional') {
+      const covered =
+        coversPropertyAs(input, prop.name, ABSENT_FORMS) ||
+        covers(input, 'empty', 'none', 'missing', 'placeholder');
+      if (!covered) {
+        gaps.push({
+          rule: 'state-optional',
+          severity: 'warning',
+          message: `"${input.component}" takes ${prop.name}: ${prop.type}, which can be absent, and no preview covers the absent case.`,
+          suggestion: `a preview with ${prop.name} set to nil, named "${input.component}/Empty"`,
+        });
+      }
+      continue;
+    }
+
+    if (prop.kind === 'collection') {
+      const covered =
+        coversPropertyAs(input, prop.name, EMPTY_FORMS) || covers(input, 'empty', 'none', 'zero');
+      if (!covered) {
+        gaps.push({
+          rule: 'state-collection',
+          severity: 'warning',
+          message: `"${input.component}" takes ${prop.name}: ${prop.type}, which can be empty, and no preview covers the empty case.`,
+          suggestion: `a preview with ${prop.name} empty, named "${input.component}/Empty"`,
+        });
+      }
+      continue;
+    }
+
+    if (prop.kind === 'enum-like') {
+      // Only when the project actually declares it as an enum. Every other
+      // named type — a class, a struct, a protocol — has no finite set of
+      // states to enumerate, and guessing at one would fill the report with
+      // work that does not exist.
+      const declared = (input.enumTypes ?? []).includes(prop.type.replace(/\s+/g, ''));
+      if (declared && stateCount(input) < 2) {
+        gaps.push({
+          rule: 'state-enum',
+          severity: 'warning',
+          message: `"${input.component}" takes ${prop.name}: ${prop.type}, an enum, and ${previewCount === 0 ? 'no preview covers any case' : 'only one preview exists'}.`,
+          suggestion: `one preview per case of ${prop.type}, named "${input.component}/<Case>"`,
+        });
+      }
+    }
+  }
+
+  if (previewCount > 0 && !input.hasDarkPreview) {
+    gaps.push({
+      rule: 'theme-dark',
+      severity: 'warning',
+      message: `"${input.component}" has no dark-theme preview, so a dark-mode regression cannot show up in the gallery.`,
+      suggestion: env.dark,
+    });
+  }
+
+  if (previewCount > 0 && !covers(input, 'dynamictypesize', 'fontscale', 'sizecategory', 'accessibility')) {
+    gaps.push({
+      rule: 'dynamic-type',
+      severity: 'info',
+      message: `"${input.component}" has no large-text preview, the configuration that most often breaks a layout.`,
+      suggestion: env.dynamicType,
+    });
+  }
+
+  // Silent on an unlocalized project: telling every repository to cover locales
+  // it does not ship would make the report noise rather than a to-do list.
+  if (previewCount > 0 && input.extraLocales.length > 0 && !covers(input, 'locale', 'environment(\\.locale', 'rtl')) {
+    const sample = input.extraLocales[0];
+    gaps.push({
+      rule: 'localization',
+      severity: 'info',
+      message: `The project ships ${input.extraLocales.length} localization${input.extraLocales.length === 1 ? '' : 's'} (${input.extraLocales.slice(0, 4).join(', ')}${input.extraLocales.length > 4 ? ', …' : ''}) and "${input.component}" is previewed in the development language only.`,
+      suggestion: env.locale(sample),
+    });
+  }
+
+  return gaps;
+}

--- a/src/scan/ios.ts
+++ b/src/scan/ios.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import type { CoverageReport, ScannedComponent, ScannedPreview } from './types.js';
 import { previewHints } from './hints.js';
+import { componentGaps, type ComponentProperty, type PropertyKind } from './gaps.js';
 
 /**
  * Regex-based heuristic scanner for SwiftUI `View` structs and `#Preview`
@@ -13,10 +14,14 @@ export async function scanIos(projectDir: string): Promise<CoverageReport> {
   const orphanPreviews: ScannedPreview[] = [];
 
   const files = await walkSwiftFiles(projectDir);
+  const extraLocales = await detectLocales(projectDir);
+  const enumTypes = new Set<string>();
 
   for (const file of files) {
     const relFile = relative(projectDir, file);
     const content = await readFile(file, 'utf8');
+
+    for (const enumName of findEnums(content)) enumTypes.add(enumName);
 
     const fileComponents = findViewStructs(content, relFile);
     const filePreviews = findPreviews(content, relFile);
@@ -28,10 +33,25 @@ export async function scanIos(projectDir: string): Promise<CoverageReport> {
   components.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
   orphanPreviews.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
 
+  for (const component of components) {
+    const gaps = componentGaps({
+      platform: 'ios',
+      component: component.name,
+      properties: component.properties ?? [],
+      previewNames: component.previews.map((p) => p.displayName ?? p.name),
+      hasDarkPreview: component.previews.some((p) => p.dark),
+      previewText: component.previews.map((p) => p.annotationText ?? '').join('\n'),
+      extraLocales,
+      enumTypes: [...enumTypes],
+    });
+    if (gaps.length > 0) component.gaps = gaps;
+  }
+
   return {
     platform: 'ios',
     components,
     orphanPreviews,
+    extraLocales,
     stats: computeStats(components, orphanPreviews),
   };
 }
@@ -41,11 +61,13 @@ function findViewStructs(content: string, relFile: string): ScannedComponent[] {
   const regex = /(?:struct|final class)\s+([A-Z]\w*)\s*:\s*[^{]*\bView\b/g;
   let match: RegExpExecArray | null;
   while ((match = regex.exec(content)) !== null) {
+    const properties = findStoredProperties(content, regex.lastIndex);
     results.push({
       name: match[1],
       file: relFile,
       line: lineNumberAt(content, match.index),
       previews: [],
+      ...(properties.length > 0 ? { properties } : {}),
     });
   }
   return results;
@@ -125,6 +147,151 @@ function extractAnnotationText(content: string, matchIndex: number): string {
   return restLines.slice(0, limit).join('\n');
 }
 
+/**
+ * Stored properties of the struct whose declaration ends at `from`.
+ *
+ * Only the declaration line matters, so this reads lines rather than parsing
+ * Swift: a stored property is `let`/`var name: Type`, optionally preceded by
+ * property wrappers and an access modifier. `var body: some View` is the one
+ * that always appears and never describes a state, and a `var` with a `{`
+ * before any `=` is computed, so both are skipped.
+ */
+function findStoredProperties(content: string, from: number): ComponentProperty[] {
+  const body = structBody(content, from);
+  const properties: ComponentProperty[] = [];
+  const declaration =
+    /^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?:(?:private|fileprivate|internal|public|package)\s+)?(?:let|var)\s+(\w+)\s*:\s*([^={\n]+)/;
+
+  for (const line of body.split('\n')) {
+    const match = line.match(declaration);
+    if (!match) continue;
+    const name = match[1];
+    const type = match[2].trim();
+    if (name === 'body') continue;
+    // Computed: a brace opens before any assignment.
+    const rest = line.slice(line.indexOf(type) + type.length);
+    if (rest.includes('{') && !rest.includes('=')) continue;
+    properties.push({ name, type, kind: classifyType(type) });
+  }
+  return properties;
+}
+
+/** Enum type names declared in this file, including indirect and raw-value enums. */
+function findEnums(content: string): string[] {
+  const results: string[] = [];
+  const regex = /(?:^|\n)\s*(?:public\s+|internal\s+|private\s+|fileprivate\s+|package\s+)?(?:indirect\s+)?enum\s+([A-Z]\w*)/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(content)) !== null) results.push(match[1]);
+  return results;
+}
+
+/** The text between the struct's opening brace and its matching close, capped. */
+function structBody(content: string, from: number): string {
+  const open = content.indexOf('{', from);
+  if (open === -1) return '';
+  let depth = 0;
+  const cap = Math.min(content.length, open + 8000);
+  for (let i = open; i < cap; i++) {
+    if (content[i] === '{') depth++;
+    else if (content[i] === '}') {
+      depth--;
+      if (depth === 0) return content.slice(open + 1, i);
+    }
+  }
+  return content.slice(open + 1, cap);
+}
+
+/** Types whose values are a spectrum rather than a set of states worth previewing. */
+const SCALAR_TYPES = new Set([
+  'String', 'Int', 'Double', 'Float', 'CGFloat', 'Date', 'URL', 'UUID', 'Data',
+  'Color', 'Font', 'Image', 'Text', 'TimeInterval', 'Any', 'AnyView',
+]);
+
+function classifyType(type: string): PropertyKind {
+  const bare = type.replace(/\s+/g, '');
+  if (bare.endsWith('?') || bare.startsWith('Optional<')) return 'optional';
+  if (bare.startsWith('[') || bare.startsWith('Set<') || bare.startsWith('Array<')) return 'collection';
+  if (bare === 'Bool') return 'bool';
+  if (SCALAR_TYPES.has(bare)) return 'other';
+  // A capitalized type of the project's own is the shape an enum takes; the
+  // agent reads it to find out whether it actually is one.
+  if (/^[A-Z]\w*$/.test(bare)) return 'enum-like';
+  return 'other';
+}
+
+/**
+ * Locales the project ships beyond its development language, from `.lproj`
+ * directories and String Catalog localizations. "Base" is not a locale.
+ */
+async function detectLocales(projectDir: string): Promise<string[]> {
+  const found = new Set<string>();
+  const developmentRegion = await readDevelopmentRegion(projectDir);
+
+  async function walk(dir: string, depth: number): Promise<void> {
+    if (depth > 6) return;
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        if (entry.name.endsWith('.lproj')) {
+          const code = entry.name.slice(0, -'.lproj'.length);
+          if (code !== 'Base') found.add(code);
+          continue;
+        }
+        await walk(join(dir, entry.name), depth + 1);
+      } else if (entry.isFile() && entry.name.endsWith('.xcstrings')) {
+        try {
+          const catalogue = JSON.parse(await readFile(join(dir, entry.name), 'utf8')) as {
+            sourceLanguage?: string;
+            strings?: Record<string, { localizations?: Record<string, unknown> }>;
+          };
+          const source = catalogue.sourceLanguage;
+          for (const entryValue of Object.values(catalogue.strings ?? {})) {
+            for (const code of Object.keys(entryValue.localizations ?? {})) {
+              if (code !== source) found.add(code);
+            }
+          }
+        } catch {
+          // A catalogue we cannot read tells us nothing; it is not an error.
+        }
+      }
+    }
+  }
+
+  await walk(projectDir, 0);
+  if (developmentRegion) found.delete(developmentRegion);
+  return [...found].sort();
+}
+
+/**
+ * The project's development language, which is not a localization of itself.
+ * Xcode records it as `developmentRegion` in the project file.
+ */
+async function readDevelopmentRegion(projectDir: string): Promise<string | undefined> {
+  let entries;
+  try {
+    entries = await readdir(projectDir, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.endsWith('.xcodeproj')) continue;
+    try {
+      const pbxproj = await readFile(join(projectDir, entry.name, 'project.pbxproj'), 'utf8');
+      const match = pbxproj.match(/developmentRegion\s*=\s*(\w+)/);
+      if (match) return match[1];
+    } catch {
+      // No readable project file: fall through and report every locale found.
+    }
+  }
+  return undefined;
+}
+
 function lineNumberAt(content: string, index: number): number {
   let line = 1;
   for (let i = 0; i < index; i++) {
@@ -190,6 +357,10 @@ function computeStats(components: ScannedComponent[], orphanPreviews: ScannedPre
     components.reduce((sum, c) => sum + c.previews.length, 0) + orphanPreviews.length;
   const allPreviews = [...components.flatMap((c) => c.previews), ...orphanPreviews];
   const hintCount = allPreviews.reduce((sum, p) => sum + (p.hints?.length ?? 0), 0);
+  const gapCount = components.reduce((sum, c) => sum + (c.gaps?.length ?? 0), 0);
+  const componentsWithGaps = components.filter((c) =>
+    (c.gaps ?? []).some((g) => g.severity === 'warning'),
+  ).length;
   // Unlike Android's @Preview (which annotates the composable itself), #Preview is
   // always a separate top-level block, so a SwiftUI View struct can't be its own
   // preview. No self-preview pattern exists here.
@@ -199,6 +370,8 @@ function computeStats(components: ScannedComponent[], orphanPreviews: ScannedPre
     withDarkPreview,
     totalPreviews,
     hintCount,
+    gapCount,
+    componentsWithGaps,
     selfPreviewed: 0,
   };
 }

--- a/src/scan/types.ts
+++ b/src/scan/types.ts
@@ -5,8 +5,9 @@
  */
 
 import type { PreviewHint } from './hints.js';
+import type { ComponentProperty, CoverageGap } from './gaps.js';
 
-export type { PreviewHint };
+export type { PreviewHint, ComponentProperty, CoverageGap };
 
 export interface ScannedPreview {
   /** Preview function name (Android) or #Preview display name / "unnamed" (iOS) */
@@ -36,6 +37,11 @@ export interface ScannedComponent {
   line: number;
   /** Previews matched to this component (same file + name-prefix heuristic) */
   previews: ScannedPreview[];
+  /** Stored properties (iOS) or composable parameters (Android). What the
+   * component's states are derived from. */
+  properties?: ComponentProperty[];
+  /** Previews this component should have and doesn't. See src/scan/gaps.ts. */
+  gaps?: CoverageGap[];
 }
 
 export interface CoverageReport {
@@ -43,6 +49,9 @@ export interface CoverageReport {
   components: ScannedComponent[];
   /** Previews that could not be matched to any discovered component */
   orphanPreviews: ScannedPreview[];
+  /** Locales the project ships beyond its development language. Empty when the
+   * project is not localized, which keeps the localization gap silent there. */
+  extraLocales: string[];
   /** Totals for a quick summary */
   stats: {
     components: number;
@@ -50,6 +59,9 @@ export interface CoverageReport {
     withDarkPreview: number;
     totalPreviews: number;
     hintCount: number;
+    gapCount: number;
+    /** Components with at least one warning-severity gap. */
+    componentsWithGaps: number;
     /** Components whose only preview is themselves (the @Preview-on-the-composable
      * pattern for screen-level composables with default parameters). */
     selfPreviewed: number;


### PR DESCRIPTION
`analyze_coverage` could only speak about previews that already existed. Its hint rules fire when a preview's *name* promises a trait its annotation never declares — `SplashContentLandscape` rendering portrait. That means a component with no previews at all, or one preview standing in for four states, produced no hints and read as fine. That is exactly the case an agent needs told about.

## What it reports now

Components carry their stored properties (iOS) or composable parameters (Android), and the states those imply become gaps when no preview covers them:

- `Bool` — two values
- optional — the absent case
- collection — the empty case
- enum — each case

Alongside them, the configurations that most often break a layout — dark theme, large text — and localization, but only for a project that ships one, so an unlocalized repository stays quiet about locales it does not have.

Phonebook still never writes a preview. The report says what is missing and how to name it; reading the component and deciding which of those states is worth covering stays with the agent. Every message ends in a suggestion it can act on, and points at `get_preview_guidance` for the template.

## Two things checked rather than guessed

**A type is only called an enum when the project declares one.** The first draft hedged — "if that type is an enum" — on every capitalized property type. On IceCubesApp that produced 127 gaps for classes and structs with no cases to enumerate. The scanner now collects `enum` / `enum class` declarations while it walks and only reports the ones it has seen: `AppTab` yes, `RouterPath` no.

**The development language is not a localization of itself.** `en` was reported as a locale to cover on an English app. It now comes from the Xcode project's `developmentRegion` and is excluded.

## The report is grouped by component

The first version was a flat list sorted by severity, which put every "has no preview" first. On a repository with a hundred of them the sixty-line cap fell before a single state gap was reached, so the specific half never reached the reader. Components are the unit now: each shows all of its gaps together, the ones missing the most come first, and the cap counts components rather than lines so what is shown is always whole.

## On a real repository

IceCubesApp — 177 components, 12 with previews, 534 gaps, 18 localizations found:

```
Missing previews (534 across 177 components)

Packages/Account/Sources/Account/Detail/AccountDetailView.swift:10 AccountDetailView (15 missing)
  [state-enum] "AccountDetailView" takes viewState: AccountDetailState, an enum, and only one preview exists. -> one preview per case of AccountDetailState, named "AccountDetailView/<Case>"
  [state-optional] "AccountDetailView" takes relationship: Relationship?, which can be absent, and no preview covers the absent case. -> a preview with relationship set to nil, named "AccountDetailView/Empty"
  [state-bool] "AccountDetailView" takes isCurrentUser: Bool, which has two states, but only one preview exists. -> one preview per value of isCurrentUser, named "AccountDetailView/<State>"
  [theme-dark] ... [dynamic-type] ... [localization] ...
```

Breakdown: 165 no-preview, 132 state-bool, 89 state-optional, 80 state-collection, 32 state-enum, 12 each of dark theme, large text and localization.

## Tests

346 pass, up from 319. New coverage: each gap rule and its suppression, property extraction from real Swift and Kotlin source (including that `body` and computed properties are skipped, and `Modifier` is not a state), enum detection distinguishing an enum from a class, `developmentRegion` exclusion, and the grouped report's ordering and component-level cap.

`tsc` clean, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)